### PR TITLE
include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(qt-rappor
     encoder.cc
     qt_hash_impl.h
     qt_hash_impl.cc
+    rappor_deps.h
     std_rand_impl.h
     std_rand_impl.cc
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(qt-rappor
     std_rand_impl.cc
     )
 target_link_libraries(qt-rappor Qt5::Core)
+target_include_directories(qt-rappor PUBLIC .)
 
 add_executable(encoder_demo encoder_demo.cc)
 target_link_libraries(encoder_demo qt-rappor)


### PR DESCRIPTION
Currently we have a horrible hack in that we copy the headers into our build directory.
Let's make things easy and clean instead.