### PR TITLE
CMake: Find qt-rappor-client by using Qt6_DIR and Qt5_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 include(GNUInstallDirs)
 
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED HINTS $ENV{Qt6_DIR} $ENV{Qt5_DIR})
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
 
 set(qt_rappor_headers


### PR DESCRIPTION
One common way to let CMake find Qt is by setting Qt5_DIR in the environment.
The new way that tries to find Qt 6 also does not respec the variable.
Pass the variable as hint to make it work again (this is the way we set
the Qt version in our CI).